### PR TITLE
Add branch name input to auto-streak-keeper

### DIFF
--- a/.github/workflow-templates/auto-streak-keeper.yml
+++ b/.github/workflow-templates/auto-streak-keeper.yml
@@ -30,3 +30,4 @@ jobs:
          user-name: ${{ secrets.GITHUB_USER_NAME }}
          user-email: ${{ secrets.GITHUB_USER_EMAIL }}
          github-token: ${{ secrets.GITHUB_TOKEN }}
+         branch-name: "auto-streak-keeper"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 ### **What's New**
 Auto-Streak Keeper is a GitHub Action designed to help maintain your GitHub streak by automating file creation, updates, and commits on a daily schedule. This initial release includes:
 
@@ -21,7 +20,7 @@ Auto-Streak Keeper is a GitHub Action designed to help maintain your GitHub stre
 - **`user-name`**: GitHub username. Default: `${{ secrets.GITHUB_USER_NAME }}`.
 - **`user-email`**: GitHub user email. Default: `${{ secrets.GITHUB_USER_EMAIL }}`.
 - **`github-token`**: GitHub token. Default: `${{ secrets.GITHUB_TOKEN }}`.
-
+- **`branch-name`** (optional): Branch name to push the updates. Default: `main`.
 
 you can set a secrets at repo setting. 
 
@@ -62,6 +61,7 @@ you can set a secrets at repo setting.
             user-name: ${{ secrets.GITHUB_USER_NAME }}
             user-email: ${{ secrets.GITHUB_USER_EMAIL }}
             github-token: ${{ secrets.GITHUB_TOKEN }}
+            branch-name: "main"
    ```
 2. Push the workflow and let the action take care of maintaining your GitHub streak!
 

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,10 @@ inputs:
   github-token:
     description: "GitHub token for authentication"
     required: true
+  branch-name:
+    description: "Branch name to push the updates"
+    required: false
+    default: "auto-streak-keeper"
 
 runs:
   using: "node20"

--- a/developer.md
+++ b/developer.md
@@ -39,7 +39,7 @@ Follow these steps to prepare and release a new version of the **Auto-Streak Kee
 - **`user-name`**: GitHub username. Default: `${{ secrets.GITHUB_USER_NAME }}`.
 - **`user-email`**: GitHub user email. Default: `${{ secrets.GITHUB_USER_EMAIL }}`.
 - **`github-token`**: GitHub token. Default: `${{ secrets.GITHUB_TOKEN }}`.
-
+- **`branch-name`** (optional): Branch name to push the updates. Default: `main`.
 
 you can set a secrets at repo setting. 
 ---
@@ -79,6 +79,7 @@ jobs:
           user-name: ${{ secrets.GITHUB_USER_NAME }}
           user-email: ${{ secrets.GITHUB_USER_EMAIL }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          branch-name: "main"
 ```
 
 ---

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ async function run() {
     const userName = core.getInput("user-name");
     const userEmail = core.getInput("user-email");
     const githubToken = core.getInput("github-token");
+    const branchName = core.getInput("branch-name") || "main";
 
     // Validate github-token
     if (!githubToken) {
@@ -25,7 +26,6 @@ async function run() {
     execSync(`git config --global user.email '${userEmail}'`);
     
     // Check if the branch exists remotely
-    const branchName = "auto-streak-keeper";
     try {
       const remoteBranchExists = execSync(
         `git ls-remote --heads origin ${branchName}`
@@ -45,12 +45,6 @@ async function run() {
         console.log(`Branch ${branchName} does not exist remotely. Creating it locally...`);
         // Create and switch to the branch locally
         execSync(`git checkout -b ${branchName}`);
-        // console.log("Adding initial commit...");
-        // fs.writeFileSync("README.md", "Initial commit for auto-streak-keeper");
-        // execSync(`git add README.md`);
-        // execSync(`git commit -m "Initial commit for auto-streak-keeper"`);
-        // // Push the branch to the remote and set up tracking
-        // execSync(`git push --set-upstream origin ${branchName}`);
       }
     } catch (error) {
       console.error(`Branch handling failed: ${error.message}`);
@@ -81,7 +75,7 @@ async function run() {
 
     // Publish the branch
     try {
-      execSync(`git push https://${userName}:${githubToken}@github.com/${process.env.GITHUB_REPOSITORY}.git auto-streak-keeper`);
+      execSync(`git push https://${userName}:${githubToken}@github.com/${process.env.GITHUB_REPOSITORY}.git ${branchName}`);
       console.log(`All ${updates} updates pushed successfully.`);
     } catch (error) {
       core.setFailed(`Error pushing updates: ${error.message}`);


### PR DESCRIPTION
Fixes #6

Add new feature to allow users to input a branch name and push directly to the main branch.

* **action.yml**
  - Add a new input `branch-name` to specify the branch name.
  - Set the default value of `branch-name` to `auto-streak-keeper`.

* **index.js**
  - Add a new input `branch-name` to get the branch name from the user.
  - Replace the hardcoded branch name `auto-streak-keeper` with the user-provided `branch-name`.

* **.github/workflow-templates/auto-streak-keeper.yml**
  - Add a new input `branch-name` to specify the branch name.
  - Set the default value of `branch-name` to `auto-streak-keeper`.

* **README.md**
  - Document the new `branch-name` input in the Inputs section.
  - Update the example usage to include the `branch-name` input.

* **developer.md**
  - Document the new `branch-name` input in the Inputs section.
  - Update the example usage to include the `branch-name` input.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bmiit145/auto-streak-keeper/pull/7?shareId=fcd8abd3-c4eb-4d6c-8940-10ba22e44da3).