### PR TITLE
Add random delay between commits to prevent bot detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Auto-Streak Keeper is a GitHub Action designed to help maintain your GitHub stre
   - Creates and pushes updates to a dedicated branch (`auto-streak-keeper`).
   - Validates and pulls the branch if it already exists remotely.
 - **GitHub Streak Maintenance**: Ensures daily activity to maintain your streak with minimal effort.
+- **Random Delay Between Commits**: Adds a random delay between 1 to 5 seconds after each commit to prevent bot detection.
 
 ## **Inputs**
 

--- a/developer.md
+++ b/developer.md
@@ -102,3 +102,9 @@ To publish a new version of the **Auto-Streak Keeper** action:
 ---
 
 This ensures the **Auto-Streak Keeper** is not only user-ready but also easy for developers to maintain and enhance. Let me know if you need further adjustments!
+
+---
+
+## **Random Delay Between Commits**
+
+To prevent bot detection on GitHub, a random delay between 1 to 5 seconds is added after each commit. This makes the commit activity appear more human-like and avoids triggering GitHub's bot detection mechanisms.

--- a/index.js
+++ b/index.js
@@ -71,6 +71,10 @@ async function run() {
       // Commit each change
       execSync(`git add ${filePath}`);
       execSync(`git commit -m "${commitMessage} - Update ${i + 1}"`);
+
+      // Add random delay between 1 to 5 seconds
+      const delay = Math.floor(Math.random() * 5000) + 1000;
+      await new Promise(resolve => setTimeout(resolve, delay));
     }
 
     // Publish the branch


### PR DESCRIPTION
Fixes #10

Add a random delay between commits to prevent bot detection on GitHub.

* **index.js**:
  - Add a random delay between 1 to 5 seconds after each commit using `setTimeout`.

* **README.md**:
  - Update documentation to reflect the new random delay feature.

* **developer.md**:
  - Update documentation to reflect the new random delay feature.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bmiit145/auto-streak-keeper/pull/11?shareId=45fa6bd7-9bdd-4363-a8e3-e66b267e22fe).